### PR TITLE
Make UI that creates proposal block

### DIFF
--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/TrustChainHelper.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/TrustChainHelper.kt
@@ -43,17 +43,26 @@ class TrustChainHelper(
     /**
      * Creates a new proposal block, using a text message as the transaction content.
      */
-    fun createProposalBlock(message: String, publicKey: ByteArray) {
+    fun createProposalBlock(message: String, publicKey: ByteArray): TrustChainBlock {
         val blockType = "demo_block"
         val transaction = mapOf("message" to message)
-        trustChainCommunity.createProposalBlock(blockType, transaction, publicKey)
+        return trustChainCommunity.createProposalBlock(blockType, transaction, publicKey)
+    }
+
+    fun createTxProposalBlock(amount: Float, publicKey: ByteArray): TrustChainBlock {
+        val blockType = "demo_tx_block"
+        val transaction = mapOf("amount" to amount)
+        return trustChainCommunity.createProposalBlock(blockType, transaction, publicKey)
     }
 
     /**
      * Creates an agreement block to a specified proposal block, using a custom transaction.
      */
-    fun createAgreementBlock(link: TrustChainBlock, transaction: TrustChainTransaction) {
-        trustChainCommunity.createAgreementBlock(link, transaction)
+    fun createAgreementBlock(
+        proposalBlock: TrustChainBlock,
+        transaction: TrustChainTransaction
+    ): TrustChainBlock {
+        return trustChainCommunity.createAgreementBlock(proposalBlock, transaction)
     }
 
     /**

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/PeersFragment.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/peers/PeersFragment.kt
@@ -84,6 +84,25 @@ class PeersFragment : BaseFragment() {
                 }
             }, "demo_block")
 
+            trustchain.registerTransactionValidator("demo_tx_block", object : TransactionValidator {
+                override fun validate(
+                    block: TrustChainBlock,
+                    database: TrustChainStore
+                ): Boolean {
+                    return block.transaction["amount"] != null
+                }
+            })
+
+            trustchain.addListener(object : BlockListener {
+                override fun shouldSign(block: TrustChainBlock): Boolean {
+                    return true
+                }
+
+                override fun onBlockReceived(block: TrustChainBlock) {
+                    Log.d("TrustChainDemo", "onBlockReceived: ${block.blockId} ${block.transaction}")
+                }
+            }, "demo_tx_block")
+
             while (isActive) {
                 val overlays = getIpv8().overlays
 

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/transfer/TransferFragment.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/transfer/TransferFragment.kt
@@ -67,11 +67,20 @@ class TransferFragment : BaseFragment() {
         }
 
         btnSendProposalBlock.setOnClickListener {
-            val amount = editTxtAmount.text.toString().toFloat()
-            val publicKey = editTxtAddress.text.toString().hexToBytes()
+            val amount = if(editTxtAmount.text != null) {
+                editTxtAmount.text.toString().toFloat()
+            } else {
+                0f
+            }
+            val publicKey = if(editTxtAddress.text != null) {
+                editTxtAddress.text.toString().hexToBytes()
+            } else {
+                "null".hexToBytes()
+            }
             trustchain.createTxProposalBlock(amount, publicKey)
-            val snack = Snackbar.make(it, "Sent $amount", Snackbar.LENGTH_LONG)
-            snack.show()
+            val bundle = bundleOf("Amount" to amount, "Public Key" to publicKey)
+            requireView().findNavController()
+                .navigate(R.id.action_transferFragment_to_transferSendFragment, bundle)
         }
     }
 

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/transfer/TransferFragment.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/transfer/TransferFragment.kt
@@ -6,60 +6,73 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
+import com.google.android.material.snackbar.Snackbar
 import com.google.zxing.integration.android.IntentIntegrator
 import com.google.zxing.integration.android.IntentResult
+import kotlinx.android.synthetic.main.fragment_transfer.*
 import kotlinx.android.synthetic.main.fragment_transfer.view.*
 import nl.tudelft.ipv8.android.demo.R
 import nl.tudelft.ipv8.android.demo.ui.BaseFragment
+import nl.tudelft.ipv8.util.hexToBytes
 import nl.tudelft.ipv8.util.toHex
 
 
 class TransferFragment : BaseFragment() {
-    private var sendOrReceive = true
+    private var isSending = true
 
-    /**
-     * Handle the toggleSwitch correctly switching views.
-     */
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view: View = inflater.inflate(R.layout.fragment_transfer, container, false)
-        val view2: View = view.findViewById(R.id.transferSendLayout) as LinearLayout
-        view2.visibility = View.VISIBLE
-        val view3: View = view.findViewById(R.id.transferReceiveLayout) as LinearLayout
-        view3.visibility = View.GONE
+        return inflater.inflate(R.layout.fragment_transfer, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        transferSendLayout.visibility = View.VISIBLE
+        transferReceiveLayout.visibility = View.GONE
+
         view.QRPK.setImageBitmap(
-            QRCodeUtils(requireActivity(), requireContext()).createQR(trustchain.getMyPublicKey().toHex())
+            QRCodeUtils(
+                requireActivity(),
+                requireContext()
+            ).createQR(trustchain.getMyPublicKey().toHex())
         )
-        view.switch1.setOnClickListener {
-            if (sendOrReceive){
-                view2.visibility = View.GONE
-                view3.visibility = View.VISIBLE
-                sendOrReceive = false;
+
+        sendReceiveSwitch.setOnClickListener {
+            if (isSending) {
+                transferSendLayout.visibility = View.GONE
+                transferReceiveLayout.visibility = View.VISIBLE
             } else {
-                view3.visibility = View.GONE
-                view2.visibility = View.VISIBLE
-                sendOrReceive = true;
+                transferReceiveLayout.visibility = View.GONE
+                transferSendLayout.visibility = View.VISIBLE
             }
+            isSending = !isSending
         }
-        view.QRPK_Next.setOnClickListener {
+
+        QRPK_Next.setOnClickListener {
             QRCodeUtils(requireActivity(), requireContext()).startQRScanner(this)
             //Temporary QR scan skip
 //            val bundle = bundleOf("Proposal Block" to "Prop blockje")
 //            view.findNavController().navigate(R.id.action_transferFragment_to_transferReceiveFragment, bundle)
         }
-        view.btnSendScan.setOnClickListener {
+
+        btnScanPk.setOnClickListener {
             QRCodeUtils(requireActivity(), requireContext()).startQRScanner(this)
             //Temporary QR scan skip
 //            val bundle = bundleOf("Public Key" to "pub keytje")
 //            view.findNavController().navigate(R.id.action_transferFragment_to_transferSendFragment, bundle)
         }
-        return view
+
+        btnSendProposalBlock.setOnClickListener {
+            val amount = editTxtAmount.text.toString().toFloat()
+            val publicKey = editTxtAddress.text.toString().hexToBytes()
+            trustchain.createTxProposalBlock(amount, publicKey)
+            val snack = Snackbar.make(it, "Sent $amount", Snackbar.LENGTH_LONG)
+            snack.show()
+        }
     }
 
     /**
@@ -68,18 +81,18 @@ class TransferFragment : BaseFragment() {
      * If the scan was successful, the appropriate new fragment is loaded, depending on the toggleSwitch
      */
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        val result: IntentResult? = IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
-        if(result != null) { // This is a result returned by the QR scanner
+        val result: IntentResult? =
+            IntentIntegrator.parseActivityResult(requestCode, resultCode, data)
+        if (result != null) { // This is a result returned by the QR scanner
             val content = result.contents
-            if(content != null) {
-                if(sendOrReceive) {
-                    // TODO: Handle parsing of qr code and passing along to new fragment
-                    val bundle = bundleOf("Public Key" to content)
-                    requireView().findNavController().navigate(R.id.action_transferFragment_to_transferSendFragment, bundle)
+            if (content != null) {
+                if (isSending) {
+                    editTxtAddress.setText(content)
                 } else {
                     // TODO: Handle parsing of qr code and passing along to new fragment
                     val bundle = bundleOf("Proposal Block" to content)
-                    requireView().findNavController().navigate(R.id.action_transferFragment_to_transferReceiveFragment, bundle)
+                    requireView().findNavController()
+                        .navigate(R.id.action_transferFragment_to_transferReceiveFragment, bundle)
                 }
             } else {
                 Log.d("QR Scan", "Scan failed")

--- a/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/transfer/TransferSendFragment.kt
+++ b/demo-android/src/main/java/nl/tudelft/ipv8/android/demo/ui/transfer/TransferSendFragment.kt
@@ -13,6 +13,7 @@ import com.google.zxing.integration.android.IntentResult
 import kotlinx.android.synthetic.main.fragment_transfer_send.view.*
 import nl.tudelft.ipv8.android.demo.R
 import nl.tudelft.ipv8.android.demo.ui.BaseFragment
+import nl.tudelft.ipv8.util.toHex
 
 class TransferSendFragment() : BaseFragment() {
 
@@ -22,9 +23,15 @@ class TransferSendFragment() : BaseFragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view: View = inflater.inflate(R.layout.fragment_transfer_send, container, false)
-        val publicKey = arguments?.get("Public Key")
+
+        val receiverPublicKey = arguments?.get("Public Key")
+//        val amount =
+//        val amount =
+//        val transaction =
+//        val block = trustchain.createProposalBlock(receiverPublicKey)
+
         val bitmap: Bitmap? = QRCodeUtils(activity, requireContext())
-            .createQR("MY Proposal BLOCK")
+            .createQR("Proposal block")
             view.proposalBlockQR.setImageBitmap(bitmap)
         view.btnProposalScannedNext.setOnClickListener {
             QRCodeUtils(requireActivity(), requireContext()).startQRScanner(this)

--- a/demo-android/src/main/res/layout/fragment_transfer.xml
+++ b/demo-android/src/main/res/layout/fragment_transfer.xml
@@ -5,13 +5,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingHorizontal="5dp"
     android:orientation="vertical">
 
     <LinearLayout
         android:id="@+id/transferLayout"
         android:orientation="vertical"
         android:gravity="top"
-        android:layout_height="100dp"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -19,7 +20,7 @@
         tools:ignore="MissingConstraints">
 
         <Switch
-            android:id="@+id/switch1"
+            android:id="@+id/sendReceiveSwitch"
             android:text="Send / Receive"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -48,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Sender to scan this QR-code containing your details:"
-            android:paddingHorizontal="6dp" />
+            android:paddingHorizontal="3dp" />
 
         <ImageView
             android:id="@+id/QRPK"
@@ -68,7 +69,7 @@
             android:layout_gravity="end"
             android:layout_marginEnd="20dp"
             android:layout_marginBottom="50dp"
-            android:padding="15dp"
+            android:padding="13dp"
             android:text="Scan"
             app:layout_constraintTop_toBottomOf="@id/ScanAfterQRPK" />
     </LinearLayout>
@@ -76,7 +77,7 @@
     <LinearLayout
         android:id="@+id/transferSendLayout"
         android:orientation="vertical"
-        android:layout_height="326dp"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:gravity="top"
         android:layout_marginTop="80dp"
@@ -85,32 +86,58 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
+            android:id="@+id/txtAddressLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="3dp"
+            android:text="Address:" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="30dp">
+
+            <EditText
+                android:id="@+id/editTxtAddress"
+                android:gravity="start"
+                android:layout_weight="1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:hint="Enter Address" />
+
+            <Button
+                android:id="@+id/btnScanPk"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:text="Scan" />
+
+        </LinearLayout>
+
+        <TextView
             android:id="@+id/txtValueLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Amount to send:"
-            android:paddingHorizontal="6dp" />
+            android:layout_marginHorizontal="3dp"
+            android:text="Amount to send:" />
 
         <EditText
-            android:id="@+id/editTxtQRInput"
-            android:gravity="left"
+            android:id="@+id/editTxtAmount"
+            android:gravity="start"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:layout_marginStart="5dp"
-            android:layout_marginBottom="20dp"
+            android:inputType="numberDecimal"
             android:hint="Enter Amount" />
 
         <Button
-            android:id="@+id/btnSendScan"
+            android:id="@+id/btnSendProposalBlock"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="20dp"
-            android:padding="15dp"
-            android:text="Scan"
-            app:layout_constraintTop_toBottomOf="@id/txtValueLabel" />
+            android:text="Send" />
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
After this pull request it should be possible to:
- Scan the receiver's QR-code
- Receive the receiver public key
- Enter the amount you want to send
- Create a proposal block

Issues: It seems like other users (including the receiver) are not receiving the proposal block, even when online. Not sure why yet. Might be network problems, but probably not. Can still be merged, as this does not break any current functionality.

PS: Got a bit carried away, and did a ton of changes to the UI. Hope this is fine, if not: let me know.